### PR TITLE
Fix typos in README files and spiral default configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ composer require schranz-templating/spiral-handlebars-integration
 
 ## Package List
 
-The current project already provides about more than ~45 packages to integrate different template
+The current project already provides about more than ~50 packages to integrate different template
 engines into different frameworks.
 
 - [x] [TemplateRendererInterface](src/TemplateRenderer/TemplateRendererInterface.php) ([`schranz-templating/template-renderer`](https://github.com/schranz-templating/template-renderer))

--- a/src/Integration/Spiral/Handlebars/README.md
+++ b/src/Integration/Spiral/Handlebars/README.md
@@ -28,8 +28,6 @@ class Kernel extends \Spiral\Framework\Kernel
 
 ## Configuration
 
-## Configuration
-
 The integration provides the following configuration.
 
 ```php
@@ -38,9 +36,7 @@ The integration provides the following configuration.
 declare(strict_types=1);
 
 return [
-    'paths' => [
-        'hello' => 'app/views',
-    ],
+    'path' => 'app/views',
     'cache_dir' => 'runtime/cache/smarty/cache',
     'compile_dir' => 'runtime/cache/smarty/compile',
 ];

--- a/src/Integration/Spiral/Smarty/Bootloader/SmartyBootloader.php
+++ b/src/Integration/Spiral/Smarty/Bootloader/SmartyBootloader.php
@@ -22,7 +22,7 @@ final class SmartyBootloader extends Bootloader
             SmartyConfig::CONFIG,
             [
                 'paths' => [
-                    'hello' => 'app/views',
+                    'app/views',
                 ],
                 'cache_dir' => 'runtime/cache/smarty/cache',
                 'compile_dir' => 'runtime/cache/smarty/compile',


### PR DESCRIPTION
Some small fixes in Spiral configuration and READMEs.