### PR TITLE
Spiral framework integration 

### DIFF
--- a/src/Adapter/Blade/BladeRenderer.php
+++ b/src/Adapter/Blade/BladeRenderer.php
@@ -2,17 +2,17 @@
 
 namespace Schranz\Templating\Adapter\Blade;
 
-use Illuminate\View\Factory;
+use Illuminate\Contracts\View\Factory as FactoryContract;
 use Schranz\Templating\TemplateRenderer\TemplateRendererInterface;
 
 class BladeRenderer implements TemplateRendererInterface
 {
     /**
-     * @var Factory
+     * @var FactoryContract
      */
     private $blade;
 
-    public function __construct(Factory $blade)
+    public function __construct(FactoryContract $blade)
     {
         $this->blade = $blade;
     }

--- a/src/Integration/Spiral/Blade/Bootloader/BladeBootloader.php
+++ b/src/Integration/Spiral/Blade/Bootloader/BladeBootloader.php
@@ -2,63 +2,74 @@
 
 namespace Schranz\Templating\Integration\Spiral\Blade\Bootloader;
 
+use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
+use Illuminate\Contracts\View\Factory as FactoryContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Engines\CompilerEngine;
 use Illuminate\View\Engines\EngineResolver;
-use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
+use Illuminate\View\ViewFinderInterface;
+use Psr\Container\ContainerInterface;
 use Schranz\Templating\Adapter\Blade\BladeRenderer;
 use Schranz\Templating\Integration\Spiral\Blade\Config\BladeConfig;
 use Schranz\Templating\TemplateRenderer\TemplateRendererInterface;
 use Spiral\Boot\Bootloader\Bootloader;
-use Spiral\Core\Container;
+use Spiral\Boot\DirectoriesInterface;
+use Spiral\Core\BinderInterface;
 use Spiral\Config\ConfiguratorInterface;
 
 final class BladeBootloader extends Bootloader
 {
+    protected const SINGLETONS = [
+        'schranz_templating.renderer.blade' => TemplateRendererInterface::class,
+        'blade' => FactoryContract::class,
+        Filesystem::class => Filesystem::class,
+        'blade.filesystem' => Filesystem::class,
+    ];
+
     public function __construct(
         private readonly ConfiguratorInterface $config
     ) {
     }
 
-    public function init(): void {
+    public function init(DirectoriesInterface $dirs): void
+    {
         $this->config->setDefaults(
             BladeConfig::CONFIG,
             [
                 'paths' => [
-                    'app/views'
+                    $dirs->get('views'),
                 ],
-                'cache_dir' => 'runtime/cache/blade',
+                'cache_dir' => $dirs->get('runtime') . '/cache/blade',
             ]
         );
     }
 
-    public function boot(Container $container): void
+    public function boot(BinderInterface $binder): void
     {
-        $container->bindSingleton('blade.filesystem', function (Container $container) {
-            return new Filesystem();
-        });
+        $binder->bindSingleton(
+            CompilerInterface::class,
+            static function (BladeConfig $config, Filesystem $filesystem): CompilerInterface {
+                return new BladeCompiler(
+                    $filesystem,
+                    $config->getCacheDir()
+                );
+            }
+        );
 
-        $container->bindSingleton('blade.compiler', function (Container $container) {
-            $config = $container->get(BladeConfig::class);
-
-            return new BladeCompiler(
-                $container->get('blade.filesystem'),
-                $config->getCacheDir()
-            );
-        });
-
-        $container->bindSingleton('blade.file_view_finder', function (Container $container) {
-            $config = $container->get(BladeConfig::class);
-
-            return new FileViewFinder(
-                $container->get('blade.filesystem'),
-                $config->getPaths()
-            );
-        });
+        $binder->bindSingleton(
+            ViewFinderInterface::class,
+            static function (BladeConfig $config, Filesystem $filesystem): ViewFinderInterface {
+                return new FileViewFinder(
+                    $filesystem,
+                    $config->getPaths()
+                );
+            }
+        );
 
         /* php closure not used when using blade for rendering but could be used this way
         $container->bindSingleton('blade.file_view_finder', function (Container $container) {
@@ -72,16 +83,16 @@ final class BladeBootloader extends Bootloader
         });
         */
 
-        $container->bindSingleton('blade.engine_resolver_blade_closure', function (Container $container) {
-            $filesystem = $container->get('blade.filesystem');
-            $bladeCompiler = $container->get('blade.compiler');
+        $binder->bindSingleton(
+            'blade.engine_resolver_blade_closure',
+            static function (Filesystem $filesystem, CompilerInterface $compiler) {
+                return static function () use ($compiler, $filesystem) {
+                    return new CompilerEngine($compiler, $filesystem);
+                };
+            }
+        );
 
-            return function () use ($bladeCompiler, $filesystem) {
-                return new CompilerEngine($bladeCompiler, $filesystem);
-            };
-        });
-
-        $container->bindSingleton('blade.engine_resolver', function (Container $container) {
+        $binder->bindSingleton(EngineResolver::class, static function (ContainerInterface $container): EngineResolver {
             $engineResolver = new EngineResolver();
 
             $engineResolver->register('blade', $container->get('blade.engine_resolver_blade_closure'));
@@ -91,25 +102,28 @@ final class BladeBootloader extends Bootloader
             return $engineResolver;
         });
 
-        $container->bindSingleton('blade.dispatcher', function (Container $container) {
-            return new Dispatcher();
-        });
+        $binder->bindSingleton(DispatcherContract::class, Dispatcher::class);
 
-        $container->bindSingleton('blade', function (Container $container) {
-            return new Factory(
-                $container->get('blade.engine_resolver'),
-                $container->get('blade.file_view_finder'),
-                $container->get('blade.dispatcher'),
-            );
-        });
+        $binder->bindSingleton(
+            FactoryContract::class,
+            static function (
+                EngineResolver $resolver,
+                ViewFinderInterface $finder,
+                DispatcherContract $dispatcher
+            ): FactoryContract {
+                return new Factory(
+                    $resolver,
+                    $finder,
+                    $dispatcher,
+                );
+            }
+        );
 
-        $container->bind(Factory::class, 'blade');
-
-        $container->bindSingleton('schranz_templating.renderer.blade', function (Container $container) {
-            return new BladeRenderer($container->get('blade'));
-        });
-
-        $container->bind(TemplateRendererInterface::class, 'schranz_templating.renderer.blade');
-        $container->bind(BladeRenderer::class, 'schranz_templating.renderer.blade');
+        $binder->bindSingleton(
+            TemplateRendererInterface::class,
+            static function (FactoryContract $factory): TemplateRendererInterface {
+                return new BladeRenderer($factory);
+            }
+        );
     }
 }

--- a/src/Integration/Spiral/Blade/composer.json
+++ b/src/Integration/Spiral/Blade/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.1",
         "schranz-templating/blade-adapter": "^0.1",
         "spiral/boot": "^3.0",
         "spiral/config": "^3.0",

--- a/src/Integration/Spiral/SpiralView/README.md
+++ b/src/Integration/Spiral/SpiralView/README.md
@@ -21,7 +21,6 @@ class Kernel extends \Spiral\Framework\Kernel
 {
     protected const LOAD = [
         // ...
-        \Spiral\Views\Bootloader\ViewsBootloader::class,
         \Schranz\Templating\Integration\Spiral\SpiralView\Bootloader\SpiralViewBootloader::class,
     ];
 }

--- a/src/Integration/Spiral/SpiralView/composer.json
+++ b/src/Integration/Spiral/SpiralView/composer.json
@@ -25,7 +25,7 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.1",
         "schranz-templating/spiral-view-adapter": "^0.1",
         "spiral/boot": "^3.0",
         "spiral/config": "^3.0",

--- a/src/Integration/Spiral/Twig/Bootloader/TwigBootloader.php
+++ b/src/Integration/Spiral/Twig/Bootloader/TwigBootloader.php
@@ -2,53 +2,41 @@
 
 namespace Schranz\Templating\Integration\Spiral\Twig\Bootloader;
 
+use Psr\Container\ContainerInterface;
 use Schranz\Templating\Adapter\Twig\TwigRenderer;
 use Schranz\Templating\TemplateRenderer\TemplateRendererInterface;
-use Spiral\Core\Container;
+use Spiral\Core\BinderInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Twig\TwigEngine;
 use Spiral\Views\ViewContext;
-use Spiral\Views\ViewManager;
 use Twig\Environment;
 
 final class TwigBootloader extends Bootloader
 {
-    public function boot(Container $container): void
+    protected const DEPENDENCIES = [
+        \Spiral\Twig\Bootloader\TwigBootloader::class,
+    ];
+
+    protected const SINGLETONS = [
+        'twig' => Environment::class,
+        'schranz_templating.renderer.twig' => TemplateRendererInterface::class,
+        TemplateRendererInterface::class => TwigRenderer::class,
+        TwigRenderer::class => TwigRenderer::class,
+    ];
+
+    public function boot(BinderInterface $binder): void
     {
-        $container->bindSingleton('twig', function (Container $container) {
-            // Use a hack to get Twig from the ViewManager as it is not available as an service yet
-            $viewManager = $container->get(ViewManager::class);
-
-            $engines = $viewManager->getEngines();
-
-            $twigEngine = null;
-            foreach ($engines as $engine) {
-                if ($engine instanceof TwigEngine) {
-                    $twigEngine = $engine;
-                    break;
-                }
-            }
-
-            if (null === $twigEngine) {
+        $binder->bindSingleton(Environment::class, static function (ContainerInterface $container): Environment {
+            try {
+                $twigEngine = $container->get(TwigEngine::class);
+            } catch (\Throwable $e) {
                 throw new \LogicException(
-                    \sprintf('Expected "%s" to be registered in the view manager.', TwigEngine::class)
+                    \sprintf('Expected "%s" to be registered in the view manager.', TwigEngine::class),
+                    previous: $e
                 );
             }
 
             return $twigEngine->getEnvironment(new ViewContext());
-        });
-
-        $container->bind(Environment::class, 'twig');
-
-        $container->bindSingleton('schranz_templating.renderer.twig', function (Container $container) {
-            return new TwigRenderer($container->get('twig'));
-        });
-
-        $container->bind(TemplateRendererInterface::class, 'schranz_templating.renderer.twig');
-        $container->bind(TwigRenderer::class, 'schranz_templating.renderer.twig');
-
-        $container->bindSingleton('schranz_templating.renderer.twig', function (Container $container) {
-            return new TwigRenderer($container->get('twig'));
         });
     }
 }

--- a/src/Integration/Spiral/Twig/README.md
+++ b/src/Integration/Spiral/Twig/README.md
@@ -21,7 +21,6 @@ class Kernel extends \Spiral\Framework\Kernel
 {
     protected const LOAD = [
         // ...
-        \Spiral\Twig\Bootloader\TwigBootloader::class,
         \Schranz\Templating\Integration\Spiral\Twig\Bootloader\TwigBootloader::class,
     ];
 }

--- a/src/Integration/Spiral/Twig/composer.json
+++ b/src/Integration/Spiral/Twig/composer.json
@@ -25,10 +25,10 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^8.1",
         "schranz-templating/twig-adapter": "^0.1",
-        "spiral/twig-bridge": "^1.0 || ^2.0",
-        "psr/container": "^1.0 || ^2.0"
+        "spiral/twig-bridge": "^2.0",
+        "spiral/core": "^3.0"
     },
     "minimum-stability": "dev",
     "config": {


### PR DESCRIPTION
Hi @alexander-schranz 

I've tried to refactor some of Bootloaders for Spiral Framework. I tried to show you how it could be if I did it.

First of all, I don't understand the reason of using string nameslike `'schranz_templating.renderer.smarty'` for container aliases.
Why don't you use class names or interfaces?

```php
$container->bindSingleton('schranz_templating.renderer.smarty', function (Container $container) {
      return new SmartyRenderer($container->get('smarty'));
});
```

When you bind closures into container you can request dependencies as function arguments. You don't need request container and then get dependencies from them.

```php
$binder->bindSingleton(
    ViewFinderInterface::class,
    static function (BladeConfig $config, Filesystem $filesystem): ViewFinderInterface {
        return new FileViewFinder(
            $filesystem,
            $config->getPaths()
        );
    }
);
```

Spiral framework Bootloader can automatically load depended bootloaders before loading current.

```php
final class SpiralViewBootloader extends Bootloader
{
    protected const DEPENDENCIES = [
        \Spiral\Views\Bootloader\ViewsBootloader::class
    ];

```