### PR TITLE
Fix Twig and Spiral View Bootloader

### DIFF
--- a/src/Integration/Spiral/SpiralView/Bootloader/SpiralViewBootloader.php
+++ b/src/Integration/Spiral/SpiralView/Bootloader/SpiralViewBootloader.php
@@ -7,7 +7,11 @@ use Schranz\Templating\Adapter\SpiralView\SpiralViewRenderer;
 use Schranz\Templating\TemplateRenderer\TemplateRendererInterface;
 use Spiral\Boot\Bootloader\Bootloader;
 use Spiral\Core\BinderInterface;
+use Spiral\Twig\TwigEngine;
 use Spiral\Views\Engine\Native\NativeEngine;
+use Spiral\Views\ViewContext;
+use Spiral\Views\ViewManager;
+use Twig\Environment;
 
 final class SpiralViewBootloader extends Bootloader
 {
@@ -22,13 +26,24 @@ final class SpiralViewBootloader extends Bootloader
 
     public function boot(BinderInterface $binder): void
     {
+        // Use a hack to get Twig from the ViewManager as it is not available as an service yet
         $binder->bindSingleton(SpiralViewRenderer::class, function (ContainerInterface $container) {
-            try {
-                $nativeEngine = $container->get(NativeEngine::class);
-            } catch (\Throwable $e) {
+            // Use a hack to get Twig from the ViewManager as it is not available as an service yet
+            $viewManager = $container->get(ViewManager::class);
+
+            $engines = $viewManager->getEngines();
+
+            $nativeEngine = null;
+            foreach ($engines as $engine) {
+                if ($engine instanceof NativeEngine) {
+                    $nativeEngine = $engine;
+                    break;
+                }
+            }
+
+            if (null === $nativeEngine) {
                 throw new \LogicException(
-                    \sprintf('Expected "%s" to be registered in the view manager.', NativeEngine::class),
-                    previous: $e
+                    \sprintf('Expected "%s" to be registered in the view manager.', NativeEngine::class)
                 );
             }
 

--- a/src/Integration/Spiral/Twig/composer.json
+++ b/src/Integration/Spiral/Twig/composer.json
@@ -28,6 +28,8 @@
         "php": "^8.1",
         "schranz-templating/twig-adapter": "^0.1",
         "spiral/twig-bridge": "^2.0",
+        "spiral/boot": "^3.0",
+        "spiral/config": "^3.0",
         "spiral/core": "^3.0"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Fixes get the TwigEngine and NativeEngine from the Container initialized. The current implementation via directly get the TwigEngine service throws an error:

> [Spiral\Views\Exception\EngineException] No associated environment found. in /Users/alexanderschranz/Documents/Projects/templating/examples/usages/spiral/vendor/spiral/twig-bridge/src/TwigEngine.php:74